### PR TITLE
Add setup files and make C++11 compat

### DIFF
--- a/demo/async/server.cpp
+++ b/demo/async/server.cpp
@@ -92,7 +92,7 @@ void server(const char* url) {
 
 	std::unique_ptr<work> works[PARALLEL];
 	for(int i=0;i<PARALLEL;++i) {
-		works[i] = std::make_unique<work>(sock);
+		works[i] = std::unique_ptr<work>(new work(sock));
 	}
 
 	sock.listen(url);

--- a/demo/raw/raw.cpp
+++ b/demo/raw/raw.cpp
@@ -94,7 +94,7 @@ void server(const char* url) {
 
 	std::unique_ptr<work> works[PARALLEL];
 	for (int i=0;i<PARALLEL;++i) {
-		works[i] = std::make_unique<work>(sock);
+		works[i] = std::unique_ptr<work>(new work(sock));
 	}
 
 	sock.listen(url);
@@ -104,7 +104,7 @@ void server(const char* url) {
 	}
 
 	while(true) {
-		nng::msleep(3'600'000); // neither pause() nor sleep() portable
+		nng::msleep(3600000); // neither pause() nor sleep() portable
 	}
 }
 

--- a/demo/rest/server.cpp
+++ b/demo/rest/server.cpp
@@ -79,7 +79,7 @@ static std::unique_ptr<rest_job> rest_get_job(void) {
 		job_lock.unlock();
 	}
 
-	job = std::make_unique<rest_job>();
+	job = std::unique_ptr<rest_job>(new rest_job);
 	if( !job ) {
 		return {};
 	}

--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 
 # defaults
-CXX = g++
+CXX = clang++-4.0
 CATCH_INC =
 NNG_INC =
 NNG_LNK = -lnng -lmbedtls -lmbedx509 -lmbedcrypto
@@ -18,8 +18,8 @@ DEMO_DIR = $(BASE_DIR)/demo
 INC_FLG = -I$(INC_DIR) -I$(NNG_INC) -I$(CATCH_INC)
 LIB_FLG = $(NNG_LNK) -lpthread
 
-REL_FLG = -Wall -Wextra -std=c++17 -march=native -O3 -DNDEBUG -Wno-unused-parameter
-DBG_FLG = -Wall -Wextra -std=c++17 -march=native -g -Wno-unused-parameter
+REL_FLG = -Wall -Wextra -std=c++11 -march=native -O3 -DNDEBUG -Wno-unused-parameter
+DBG_FLG = -Wall -Wextra -std=c++11 -march=native -g -Wno-unused-parameter
 
 TEST_FILES = $(shell echo $(TEST_DIR)/*.cpp)
 TEST_BIN = $(BIN_DIR)/test

--- a/run_perf.sh
+++ b/run_perf.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="$1"
+
+pkill local_lat || true
+pkill local_thr || true
+
+for SIZE in 8 64 512 4096 32768 262144 1000000
+do
+    echo
+    echo Message size of $SIZE bytes:
+
+    bin/perf/local_lat "$MODE://127.0.0.1:5555" "$SIZE" 1000 &
+    pid=$!
+    sleep 1
+    bin/perf/remote_lat  "$MODE://127.0.0.1:5555" "$SIZE" 1000
+    wait $pid
+
+    bin/perf/local_thr "$MODE://127.0.0.1:5555" "$SIZE" 1000 &
+    pid=$!
+    sleep 1
+    bin/perf/remote_thr  "$MODE://127.0.0.1:5555" "$SIZE" 1000
+    wait $pid
+done
+
+pkill local_lat || true
+pkill local_thr || true

--- a/setup_catch2.sh
+++ b/setup_catch2.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd ~/Downloads
+wget https://github.com/catchorg/Catch2/archive/v2.3.0.tar.gz
+gunzip -c v2.3.0.tar.gz | tar xvf -
+cd Catch2-2.3.0
+mkdir build
+cd build
+cmake ../
+make -j
+sudo make install

--- a/setup_mbedtls.sh
+++ b/setup_mbedtls.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd ~/Downloads
+wget https://tls.mbed.org/download/start/mbedtls-2.12.0-apache.tgz
+gunzip -c mbedtls-2.12.0-apache.tgz | tar xvf -
+cd mbedtls-2.12.0
+mkdir build
+cd build
+cmake ../
+make -j
+sudo make install

--- a/setup_nng.sh
+++ b/setup_nng.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd ~/Downloads
+wget https://github.com/nanomsg/nng/archive/v1.0.1.tar.gz
+gunzip -c v1.0.1.tar.gz | tar xvf -
+cd nng-1.0.1
+mkdir build
+cd build
+cmake ../
+make -j
+sudo make install


### PR DESCRIPTION
C++11 doesn't include a `make_unique` method, nor separator marks. I also changed the compiler flags and the compiler to be used for my own purposes, but I'm happy to remove those changes if you like.

I also added scripts that allowed me to build this package under Ubuntu 14.04. They're by no means generic, but they'll work for most modern Linux distros.