### PR TITLE
added cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required (VERSION 3.1)
+project(nngpp CXX)
+
+include(GNUInstallDirs)
+
+option(NNGPP_BUILD_DEMOS "build nngpp demos" off)
+option(NNGPP_BUILD_TESTS "build nngpp tests" off)
+
+set(CMAKE_CXX_STANDARD 14)
+
+find_package(nng)
+
+file(GLOB_RECURSE includes include/*.h)
+
+add_library(nngpp INTERFACE)
+target_include_directories(nngpp INTERFACE $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(nngpp INTERFACE nng::nng)
+
+if (NNGPP_BUILD_DEMOS)
+    add_subdirectory(demo)
+endif()
+
+if (NNGPP_BUILD_TESTS)
+    option(NNGPP_BUILD_TLS_TEST "build nngpp tls tests (requires mbedtls)" off)
+    add_subdirectory(test)
+endif()
+
+install(TARGETS nngpp EXPORT nngpp-target)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(EXPORT nngpp-target DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/nngpp
+        NAMESPACE nng:: FILE nngpp-config.cmake)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,24 @@
+add_executable(async_server async/server.cpp)
+target_link_libraries(async_server nngpp)
+target_include_directories(async_server PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(async_client async/client.cpp)
+target_link_libraries(async_client nngpp)
+target_include_directories(async_client PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(http_client http_client/http_client.cpp)
+target_link_libraries(http_client nngpp)
+target_include_directories(http_client PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(raw raw/raw.cpp)
+target_link_libraries(raw nngpp)
+target_include_directories(raw PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(reqrep reqrep/reqrep.cpp)
+target_link_libraries(reqrep nngpp)
+target_include_directories(reqrep PUBLIC ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(rest rest/server.cpp)
+target_link_libraries(rest nngpp)
+target_include_directories(rest PUBLIC ${CMAKE_SOURCE_DIR}/include)
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,25 @@
+find_package(Catch2)
+
+set(test_sources
+    bus.cpp
+    device.cpp
+    hello_world.cpp
+    http_client.cpp
+    ipcsupp.cpp
+    main.cpp
+    message.cpp
+    pipe.cpp
+    reconnect.cpp
+    respondpoll.cpp
+    scalability.cpp
+    synch.cpp
+    tcpsupp.cpp
+)
+
+if (NNGPP_BUILD_TLS_TEST)
+    list(APPEND test_sources tls.cpp)
+endif()
+
+add_executable(tests ${test_sources})
+target_include_directories(tests PUBLIC ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(tests nngpp Catch2::Catch2)


### PR DESCRIPTION
added cmake support to (build) and install the lib and cmake config files.
Other cmake based projects can simply use:
```
find_package(nng)
find_package(nngpp)
add_executable(sometarget somesources)
target_link_libraries(sometarget nng::nngpp)
```
to get the correct compiler and linker flags.
if nng was compiled and installed with mbedtls support, the mbedtls libraries are also linked automatically.

setting  `NNGPP_BUILD_DEMOS=on` will build demos
setting `NNGPP_BUILD_TESTS=on`will build tests (this requires Catch2)
setting `NNGPP_BUILD_TLS_TEST=on` will include tls testcases in the tests ( this requires nng with mbedtls support)