### PR TITLE
Implement std::system_error

### DIFF
--- a/include/nngpp/error.h
+++ b/include/nngpp/error.h
@@ -1,7 +1,7 @@
 #ifndef NNGPP_ERROR_H
 #define NNGPP_ERROR_H
 #include <nng/nng.h>
-#include <exception>
+#include <system_error>
 
 namespace nng {
 
@@ -47,17 +47,78 @@ inline const char* to_string( error e ) noexcept {
 	return nng_strerror( (int)e );
 }
 
-class exception : public std::exception {
+class error_category : public std::error_category {
+public:
+	static const error_category& get()    {static error_category e; return e;}
+
+	~error_category() final {}
+
+	const char *name() const noexcept final {
+		return "nng";
+	}
+
+	std::string message(int code) const final {
+		return nng_strerror(code);
+	}
+
+	std::error_condition default_error_condition(int code) const noexcept final {
+		// Transport- and system-specific
+		if (code & NNG_ESYSERR) {
+			// Attempt to translate system-specific error
+			return std::system_category().default_error_condition(code & ~int(NNG_ESYSERR));
+		}
+		switch ((error) code) {
+			// Most NNG codes have a corresponding POSIX code and hence std::erc.
+		case error::success:     return std::errc(0);
+		case error::intr:        return std::errc::interrupted;
+		case error::nomem:       return std::errc::not_enough_memory;
+		case error::inval:       return std::errc::invalid_argument;
+		case error::busy:        return std::errc::device_or_resource_busy;
+		case error::timedout:    return std::errc::timed_out;
+		case error::connrefused: return std::errc::connection_refused;
+		case error::again:       return std::errc::resource_unavailable_try_again;
+		case error::notsup:      return std::errc::not_supported;
+		case error::addrinuse:   return std::errc::address_in_use;
+		case error::noent:       return std::errc::no_such_file_or_directory;
+		case error::proto:       return std::errc::protocol_error;
+		case error::perm:        return std::errc::operation_not_permitted;
+		case error::msgsize:     return std::errc::message_size;
+		case error::connaborted: return std::errc::connection_aborted;
+		case error::connreset:   return std::errc::connection_reset;
+		case error::canceled:    return std::errc::operation_canceled;
+		case error::nospc:       return std::errc::no_space_on_device;
+		case error::exist:       return std::errc::file_exists;
+			// These NNG errors have approximate 1:1 mappings to POSIX codes.
+		case error::unreachable: return std::errc::host_unreachable;
+		case error::addrinval:   return std::errc::address_not_available;
+		case error::state:       return std::errc::inappropriate_io_control_operation;
+		case error::closed:      return std::errc::bad_file_descriptor;
+		case error::nofiles:     return std::errc::too_many_files_open;
+			// These NNG errors have a "lossy" N-to-1 mapping to POSIX codes.
+		case error::readonly:    return std::errc::permission_denied;
+		case error::writeonly:   return std::errc::permission_denied;
+		case error::crypto:      return std::errc::permission_denied;
+		case error::peerauth:    return std::errc::permission_denied;
+		case error::noarg:       return std::errc::invalid_argument;
+		case error::ambiguous:   return std::errc::invalid_argument;
+		case error::badtype:     return std::errc::invalid_argument;
+		case error::connshut:    return std::errc::connection_aborted;
+			// Continue using this category for unknown, internal and protocol errors.
+		default: return std::error_condition(code, get());
+		}
+	}
+};
+
+class exception : public std::system_error {
 	const char* source;
-	int err;
 public:
 	
-	explicit exception( int e, const char* s = "" ) noexcept : source(s), err(e) {}
+	explicit exception( int e, const char* s = "" ) noexcept : std::system_error(e,error_category::get()), source(s) {}
 
 	explicit exception( error e, const char* s = "" ) noexcept : exception((int)e,s) {}
 	
 	error get_error() const noexcept {
-		return (error)err;
+		return (error) code().value();
 	}
 
 	const char* who() const noexcept {
@@ -65,7 +126,7 @@ public:
 	}
 	
 	const char* what() const noexcept final {
-		return nng_strerror(err);
+		return nng_strerror(code().value());
 	}
 };
 


### PR DESCRIPTION
This patch adds functionality to nng::exception, making it inherit from and implement `std::system_error`, the standard interface for exceptions based on a numeric code which can be translated into a string name.

This allows:

* Using NNG exceptions in `std::error_code` and `std::error_condition`.
* Type erasure with other systems of error codes.
* Translating NNG error codes to the POSIX error codes defined in C++11.

No existing functionality is changed or removed.

------

The most complicated detail of this patch is the translation to POSIX error codes.  Although the standard does not mandate the use of the generic category in `default_error_condition`, it allows for greater practical similarity with other libraries and can be achieved with only minor wrinkles.

Mappings are implemented as described in https://github.com/cwzx/nngpp/issues/25 where I proposed this functionality.  Notably, I'm not sure whether I'm handling NNG_ESYSERR-flagged codes correctly in `default_error_condition`.

Here's the result of a diagnostic test mapping error codes 0-31, 1000 (EINTERNAL) and ESYSERR|`0xC0000005` to their generic equivalents.  This was compiled on MSVC:

```
nng     0       Hunky dory
generic 0       unknown error
nng     1       Interrupted
generic 4       interrupted
nng     2       Out of memory
generic 12      not enough memory
nng     3       Invalid argument
generic 22      invalid argument
nng     4       Resource busy
generic 16      device or resource busy
nng     5       Timed out
generic 138     timed out
nng     6       Connection refused
generic 107     connection refused
nng     7       Object closed
generic 9       bad file descriptor
nng     8       Try again
generic 11      resource unavailable try again
nng     9       Not supported
generic 129     not supported
nng     10      Address in use
generic 100     address in use
nng     11      Incorrect state
generic 25      inappropriate io control operation
nng     12      Entry not found
generic 2       no such file or directory
nng     13      Protocol error
generic 134     protocol error
nng     14      Destination unreachable
generic 110     host unreachable
nng     15      Address invalid
generic 101     address not available
nng     16      Permission denied
generic 1       operation not permitted
nng     17      Message too large
generic 115     message size
nng     18      Connection aborted
generic 106     connection aborted
nng     19      Connection reset
generic 108     connection reset
nng     20      Operation canceled
generic 105     operation canceled
nng     21      Out of files
generic 24      too many files open
nng     22      Out of space
generic 28      no space on device
nng     23      Resource already exists
generic 17      file exists
nng     24      Read only resource
generic 13      permission denied
nng     25      Write only resource
generic 13      permission denied
nng     26      Cryptographic error
generic 13      permission denied
nng     27      Peer could not be authenticated
generic 13      permission denied
nng     28      Option requires argument
generic 22      invalid argument
nng     29      Ambiguous option
generic 22      invalid argument
nng     30      Incorrect type
generic 22      invalid argument
nng     31      Connection shutdown
generic 106     connection aborted
nng     1000    Internal error detected
nng     1000    Internal error detected
nng     -805306363      Unknown error
system  -1073741819     unknown error
```